### PR TITLE
回答結果一覧の不具合修正

### DIFF
--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -55,13 +55,13 @@ class ConversationController extends Controller
      */
     function result() {
         //取得してから表示だから、取得内容を先に書く！変数は複数形にしたほうがわかりやすい
-        $answer_histories = AnswerHistory::select(['answer_histories.answer', 'questions.content','questions.answer as correct', 'questions.type'])
+        $answer_histories = AnswerHistory::select(['answer_histories.id', 'answer_histories.answer', 'questions.content','questions.answer as correct', 'questions.type'])
         ->join('questions', 'answer_histories.question_id', '=', 'questions.id')
         ->where('answer_histories.user_id', '=', \Auth::id())
-        ->where('questions.type', '=', 2)
-        ->orderBy('answer_histories.question_id', 'DESC')
+        ->orderBy('answer_histories.id', 'DESC')
         ->take(10)
-        ->get();
+        ->get()
+        ->sortBy('id');
 
 
       return view('conversation/result', compact('answer_histories'));

--- a/app/Http/Controllers/OutputController.php
+++ b/app/Http/Controllers/OutputController.php
@@ -57,13 +57,13 @@ class OutputController extends Controller
     function result() {
 
         //取得してから表示だから、取得内容を先に書く！変数は複数形にしたほうがわかりやすい
-        $answer_histories = AnswerHistory::select(['answer_histories.answer', 'questions.content','questions.answer as correct', 'questions.type'])
+        $answer_histories = AnswerHistory::select(['answer_histories.id', 'answer_histories.answer', 'questions.content','questions.answer as correct', 'questions.type'])
         ->join('questions', 'answer_histories.question_id', '=', 'questions.id')
         ->where('answer_histories.user_id', '=', \Auth::id())
-        ->where('questions.type', '=', 1)
-        ->orderBy('answer_histories.answer', 'DESC')
+        ->orderBy('answer_histories.id', 'DESC')
         ->take(10)
-        ->get();
+        ->get()
+        ->sortBy('id');
 
         return view('output/result', compact('answer_histories'));
     }

--- a/app/Http/Controllers/TotalController.php
+++ b/app/Http/Controllers/TotalController.php
@@ -46,13 +46,13 @@ class TotalController extends Controller
     }
 
     function result() {
-        $answer_histories = AnswerHistory::select(['answer_histories.answer', 'questions.content', 'questions.answer as correct'])
+        $answer_histories = AnswerHistory::select(['answer_histories.id', 'answer_histories.answer', 'questions.content', 'questions.answer as correct'])
             ->join('questions', 'answer_histories.question_id', '=', 'questions.id')
             ->where('answer_histories.user_id', '=', \Auth::id())
-            ->orderBy('answer_histories.question_id', 'DESC')
+            ->orderBy('answer_histories.id', 'DESC')
             ->take(10)
-            ->get();
-        dd($answer_histories);
+            ->get()
+            ->sortBy('id');
         return view('total/result', compact('answer_histories'));
     }
 }

--- a/app/Http/Controllers/WordController.php
+++ b/app/Http/Controllers/WordController.php
@@ -58,13 +58,13 @@ class WordController extends Controller
      * 結果を表示する処理
      */
     function result() {
-        $answer_histories = AnswerHistory::select(['answer_histories.answer', 'questions.content', 'questions.answer as correct', 'questions.type'])
+        $answer_histories = AnswerHistory::select(['answer_histories.id', 'answer_histories.answer', 'questions.content', 'questions.answer as correct', 'questions.type'])
         ->join('questions', 'answer_histories.question_id', '=', 'questions.id')
         ->where('answer_histories.user_id', '=', \Auth::id())
-        ->where('questions.type', '=', 3)
-        ->orderBy('answer_histories.question_id', 'DESC')
+        ->orderBy('answer_histories.id', 'DESC')
         ->take(10)
-        ->get();
+        ->get()
+        ->sortBy('id');
         return view('word/result', compact('answer_histories'));
     }
 


### PR DESCRIPTION
## 原因
「question_idの降順」で取得していたため、IDが大きい単語形式の問題しか表示されないようになっていた。

## 修正点
「answer_historiesのID降順」で取得して、直近で解いた問題を取得するように修正